### PR TITLE
Add @mongodb-js/dbx-devtools as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @mongodb-js/dbx-devtools
+/.github/CODEOWNERS @mongodb-js/dbx-devtools-admins


### PR DESCRIPTION
This PR adds @mongodb-js/dbx-devtools as codeowner for the entire repository.